### PR TITLE
Update to 7.9.0

### DIFF
--- a/Formula/libvirt.rb
+++ b/Formula/libvirt.rb
@@ -89,7 +89,17 @@ class Libvirt < Formula
         system "meson", "install"
       end
     end
-  
+
+    def post_install
+    # Since macOS doesn't support QEMU security features, we need to disable them:
+      on_macos do
+        qemu_conf = etc/"libvirt/qemu.conf"
+        qemu_conf.append_lines "security_driver = \"none\""
+        qemu_conf.append_lines "dynamic_ownership = 0"
+        qemu_conf.append_lines "remember_owner = 0"
+      end
+    end
+
     service do
       run [opt_sbin/"libvirtd", "-f", etc/"libvirt/libvirtd.conf"]
       keep_alive true

--- a/Formula/libvirt.rb
+++ b/Formula/libvirt.rb
@@ -5,7 +5,7 @@ class Libvirt < Formula
     sha256 "829cf2b5f574279c40f0446e1168815d3f36b89710560263ca2ce70256f72e8c"
     license all_of: ["LGPL-2.1-or-later", "GPL-2.0-or-later"]
     head "https://github.com/libvirt/libvirt.git", branch: "master"
-  
+
     livecheck do
       url "https://libvirt.org/sources/"
       regex(/href=.*?libvirt[._-]v?(\d+(?:\.\d+)+)\.t/i)
@@ -78,7 +78,7 @@ class Libvirt < Formula
           --localstatedir=#{var}
           --mandir=#{man}
           --sysconfdir=#{etc}
-          -Dqemu_datadir=HOMEBREW_PREFIX/share
+          -Dqemu_datadir=HOMEBREW_PREFIX/"share/qemu"
           -Ddriver_esx=enabled
           -Ddriver_qemu=enabled
           -Ddriver_network=enabled

--- a/Formula/libvirt.rb
+++ b/Formula/libvirt.rb
@@ -45,74 +45,74 @@ class Libvirt < Formula
     sha256 "6a17eaaab58b7d922f174a4a67b2ebb7b981838e6728abf24741483c215e4da0"
   end
   
-    depends_on "docutils" => :build
-    depends_on "meson" => :build
-    depends_on "ninja" => :build
-    depends_on "perl" => :build
-    depends_on "pkg-config" => :build
-    depends_on "python@3.9" => :build
-    depends_on "gettext"
-    depends_on "glib"
-    depends_on "gnu-sed"
-    depends_on "gnutls"
-    depends_on "grep"
-    depends_on "libgcrypt"
-    depends_on "libiscsi"
-    depends_on "libssh2"
-    depends_on "yajl"
-  
-    uses_from_macos "curl"
-    uses_from_macos "libxslt"
-  
-    on_macos do
-      depends_on "rpcgen" => :build
-    end
-  
-    on_linux do
-      depends_on "libtirpc"
-    end
-  
-    def install
-      mkdir "build" do
-        args = %W[
-          --localstatedir=#{var}
-          --mandir=#{man}
-          --sysconfdir=#{etc}
-          -Dqemu_datadir=#{HOMEBREW_PREFIX}/share/qemu
-          -Ddriver_esx=enabled
-          -Ddriver_qemu=enabled
-          -Ddriver_network=enabled
-          -Dinit_script=none
-        ]
-        system "meson", *std_meson_args, *args, ".."
-        system "meson", "compile"
-        system "meson", "install"
-      end
-    end
+  depends_on "docutils" => :build
+  depends_on "meson" => :build
+  depends_on "ninja" => :build
+  depends_on "perl" => :build
+  depends_on "pkg-config" => :build
+  depends_on "python@3.9" => :build
+  depends_on "gettext"
+  depends_on "glib"
+  depends_on "gnu-sed"
+  depends_on "gnutls"
+  depends_on "grep"
+  depends_on "libgcrypt"
+  depends_on "libiscsi"
+  depends_on "libssh2"
+  depends_on "yajl"
 
-    def post_install
-    # Since macOS doesn't support QEMU security features, we need to disable them:
-      on_macos do
-        qemu_conf = etc/"libvirt/qemu.conf"
-        qemu_conf.append_lines "security_driver = \"none\""
-        qemu_conf.append_lines "dynamic_ownership = 0"
-        qemu_conf.append_lines "remember_owner = 0"
-      end
-    end
+  uses_from_macos "curl"
+  uses_from_macos "libxslt"
 
-    service do
-      run [opt_sbin/"libvirtd", "-f", etc/"libvirt/libvirtd.conf"]
-      keep_alive true
-      environment_variables PATH: HOMEBREW_PREFIX/"bin"
-    end
-  
-    test do
-      if build.head?
-        output = shell_output("#{bin}/virsh -V")
-        assert_match "Compiled with support for:", output
-      else
-        output = shell_output("#{bin}/virsh -v")
-        assert_match version.to_s, output
-      end
+  on_macos do
+    depends_on "rpcgen" => :build
+  end
+
+  on_linux do
+    depends_on "libtirpc"
+  end
+
+  def install
+    mkdir "build" do
+      args = %W[
+        --localstatedir=#{var}
+        --mandir=#{man}
+        --sysconfdir=#{etc}
+        -Dqemu_datadir=#{HOMEBREW_PREFIX}/share/qemu
+        -Ddriver_esx=enabled
+        -Ddriver_qemu=enabled
+        -Ddriver_network=enabled
+        -Dinit_script=none
+      ]
+      system "meson", *std_meson_args, *args, ".."
+      system "meson", "compile"
+      system "meson", "install"
     end
   end
+
+  def post_install
+  # Since macOS doesn't support QEMU security features, we need to disable them:
+    on_macos do
+      qemu_conf = etc/"libvirt/qemu.conf"
+      qemu_conf.append_lines "security_driver = \"none\""
+      qemu_conf.append_lines "dynamic_ownership = 0"
+      qemu_conf.append_lines "remember_owner = 0"
+    end
+  end
+
+  service do
+    run [opt_sbin/"libvirtd", "-f", etc/"libvirt/libvirtd.conf"]
+    keep_alive true
+    environment_variables PATH: HOMEBREW_PREFIX/"bin"
+  end
+
+  test do
+    if build.head?
+      output = shell_output("#{bin}/virsh -V")
+      assert_match "Compiled with support for:", output
+    else
+      output = shell_output("#{bin}/virsh -v")
+      assert_match version.to_s, output
+    end
+  end
+end

--- a/Formula/libvirt.rb
+++ b/Formula/libvirt.rb
@@ -16,6 +16,34 @@ class Libvirt < Formula
         url "https://github.com/ihsakashi/libvirt/commit/0f062221ae23e6ea0ed5e6ba65d47395581cb143.patch"
         sha256 "1fa95c485e6cd27bd9b6ac1af9f3d1cdd1f7d7e1baa472e35b5fd3c5f940cf13"
     end
+
+
+    # [libvirt PATCH 0/5] meson: Introduce qemu_datadir option - https://listman.redhat.com/archives/libvir-list/2021-November/msg00425.html
+    # [libvirt PATCH 1/5] meson: Define qemu_moddir correctly - https://listman.redhat.com/archives/libvir-list/2021-November/msg00426.html
+    patch :p1 do
+      url "https://github.com/libvirt/libvirt/commit/591cb9d0d5e40eeff60cb18845197508b2878940.patch"
+      sha256 "ef24eb83a328e391bb44684e9664b3c4083b9c60864a78c22b7c0ea5268926f6"
+  end
+  # [libvirt PATCH 2/5] qemu: Set QEMU data location correctly - https://listman.redhat.com/archives/libvir-list/2021-November/msg00427.html
+  patch :p1 do
+      url "https://github.com/libvirt/libvirt/commit/b41c95af5b0d9f9cdb02105fc08a5c0cf6a50882.patch"
+      sha256 "4a44e112c8f24f9d8d6dcf9400115b50415d064f29a82649292e6b7d6b02f50d"
+  end
+  # [libvirt PATCH 3/5] qemu: Rename interop locations - https://listman.redhat.com/archives/libvir-list/2021-November/msg00428.html
+  patch :p1 do
+    url "https://github.com/libvirt/libvirt/commit/c46c2e15d1d1d30c5d1c9a62715d659a906a3d1e.patch"
+    sha256 "6c2746662499cded00c2e75e7c12ef630cc3107c142766ebaba7a0bd8d87032b"
+  end
+  # [libvirt PATCH 4/5] meson: Introduce qemu_datadir option - https://listman.redhat.com/archives/libvir-list/2021-November/msg00429.html
+  patch :p1 do
+    url "https://github.com/libvirt/libvirt/commit/794af15f24efd4496aef2afaeb6d30cb5a7b4e63.patch"
+    sha256 "76e1f061898c51cb1c6912671638a202b88ff1d191884e6cee2581532d031633"
+  end
+  # [libvirt PATCH 5/5] spec: Explicitly provide locations for QEMU data - https://listman.redhat.com/archives/libvir-list/2021-November/msg00430.html
+  patch :p1 do
+    url "https://github.com/libvirt/libvirt/commit/c5dc658ea8c764f0e6b15fa4da9daff97a8d2ccf.patch"
+    sha256 "6a17eaaab58b7d922f174a4a67b2ebb7b981838e6728abf24741483c215e4da0"
+  end
   
     depends_on "docutils" => :build
     depends_on "meson" => :build
@@ -50,6 +78,7 @@ class Libvirt < Formula
           --localstatedir=#{var}
           --mandir=#{man}
           --sysconfdir=#{etc}
+          -Dqemu_datadir=HOMEBREW_PREFIX/share
           -Ddriver_esx=enabled
           -Ddriver_qemu=enabled
           -Ddriver_network=enabled

--- a/Formula/libvirt.rb
+++ b/Formula/libvirt.rb
@@ -78,7 +78,7 @@ class Libvirt < Formula
           --localstatedir=#{var}
           --mandir=#{man}
           --sysconfdir=#{etc}
-          -Dqemu_datadir=HOMEBREW_PREFIX/"share/qemu"
+          -Dqemu_datadir=#{HOMEBREW_PREFIX}/share/qemu
           -Ddriver_esx=enabled
           -Ddriver_qemu=enabled
           -Ddriver_network=enabled

--- a/Formula/libvirt.rb
+++ b/Formula/libvirt.rb
@@ -1,25 +1,22 @@
 class Libvirt < Formula
     desc "C virtualization API"
     homepage "https://www.libvirt.org"
-    url "https://libvirt.org/sources/libvirt-7.3.0.tar.xz"
-    sha256 "27bdbb85c0301475ab1f2ecd185c629ea0bfd5512bef3f6f1817b6c55d1dc1be"
+    url "https://libvirt.org/sources/libvirt-7.9.0.tar.xz"
+    sha256 "829cf2b5f574279c40f0446e1168815d3f36b89710560263ca2ce70256f72e8c"
     license all_of: ["LGPL-2.1-or-later", "GPL-2.0-or-later"]
+    head "https://github.com/libvirt/libvirt.git", branch: "master"
   
     livecheck do
       url "https://libvirt.org/sources/"
       regex(/href=.*?libvirt[._-]v?(\d+(?:\.\d+)+)\.t/i)
     end
   
-    head do
-      url "https://github.com/libvirt/libvirt.git"
-    end
-
-		# apple silicon detection
+    # apple silicon detection
     patch :p1 do
-			url "https://github.com/ihsakashi/libvirt/commit/0f062221ae23e6ea0ed5e6ba65d47395581cb143.patch"
-			sha256 "1fa95c485e6cd27bd9b6ac1af9f3d1cdd1f7d7e1baa472e35b5fd3c5f940cf13"
+        url "https://github.com/ihsakashi/libvirt/commit/0f062221ae23e6ea0ed5e6ba65d47395581cb143.patch"
+        sha256 "1fa95c485e6cd27bd9b6ac1af9f3d1cdd1f7d7e1baa472e35b5fd3c5f940cf13"
     end
-
+  
     depends_on "docutils" => :build
     depends_on "meson" => :build
     depends_on "ninja" => :build
@@ -55,6 +52,7 @@ class Libvirt < Formula
           --sysconfdir=#{etc}
           -Ddriver_esx=enabled
           -Ddriver_qemu=enabled
+          -Ddriver_network=enabled
           -Dinit_script=none
         ]
         system "meson", *std_meson_args, *args, ".."
@@ -63,34 +61,10 @@ class Libvirt < Formula
       end
     end
   
-    plist_options manual: "libvirtd"
-  
-    def plist
-      <<~EOS
-        <?xml version="1.0" encoding="UTF-8"?>
-        <!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-        <plist version="1.0">
-          <dict>
-            <key>EnvironmentVariables</key>
-            <dict>
-              <key>PATH</key>
-              <string>#{HOMEBREW_PREFIX}/bin</string>
-            </dict>
-            <key>Label</key>
-            <string>#{plist_name}</string>
-            <key>ProgramArguments</key>
-            <array>
-              <string>#{sbin}/libvirtd</string>
-              <string>-f</string>
-              <string>#{etc}/libvirt/libvirtd.conf</string>
-            </array>
-            <key>KeepAlive</key>
-            <true/>
-            <key>RunAtLoad</key>
-            <true/>
-          </dict>
-        </plist>
-      EOS
+    service do
+      run [opt_sbin/"libvirtd", "-f", etc/"libvirt/libvirtd.conf"]
+      keep_alive true
+      environment_variables PATH: HOMEBREW_PREFIX/"bin"
     end
   
     test do
@@ -102,4 +76,4 @@ class Libvirt < Formula
         assert_match version.to_s, output
       end
     end
-end
+  end

--- a/Formula/libvirt.rb
+++ b/Formula/libvirt.rb
@@ -1,28 +1,28 @@
 class Libvirt < Formula
-    desc "C virtualization API"
-    homepage "https://www.libvirt.org"
-    url "https://libvirt.org/sources/libvirt-7.9.0.tar.xz"
-    sha256 "829cf2b5f574279c40f0446e1168815d3f36b89710560263ca2ce70256f72e8c"
-    license all_of: ["LGPL-2.1-or-later", "GPL-2.0-or-later"]
-    head "https://github.com/libvirt/libvirt.git", branch: "master"
+  desc "C virtualization API"
+  homepage "https://www.libvirt.org"
+  url "https://libvirt.org/sources/libvirt-7.9.0.tar.xz"
+  sha256 "829cf2b5f574279c40f0446e1168815d3f36b89710560263ca2ce70256f72e8c"
+  license all_of: ["LGPL-2.1-or-later", "GPL-2.0-or-later"]
+  head "https://github.com/libvirt/libvirt.git", branch: "master"
 
-    livecheck do
-      url "https://libvirt.org/sources/"
-      regex(/href=.*?libvirt[._-]v?(\d+(?:\.\d+)+)\.t/i)
-    end
-  
-    # apple silicon detection
-    patch :p1 do
-        url "https://github.com/ihsakashi/libvirt/commit/0f062221ae23e6ea0ed5e6ba65d47395581cb143.patch"
-        sha256 "1fa95c485e6cd27bd9b6ac1af9f3d1cdd1f7d7e1baa472e35b5fd3c5f940cf13"
-    end
+  livecheck do
+    url "https://libvirt.org/sources/"
+    regex(/href=.*?libvirt[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
+  # apple silicon detection
+  patch :p1 do
+      url "https://github.com/ihsakashi/libvirt/commit/0f062221ae23e6ea0ed5e6ba65d47395581cb143.patch"
+      sha256 "1fa95c485e6cd27bd9b6ac1af9f3d1cdd1f7d7e1baa472e35b5fd3c5f940cf13"
+  end
 
 
-    # [libvirt PATCH 0/5] meson: Introduce qemu_datadir option - https://listman.redhat.com/archives/libvir-list/2021-November/msg00425.html
-    # [libvirt PATCH 1/5] meson: Define qemu_moddir correctly - https://listman.redhat.com/archives/libvir-list/2021-November/msg00426.html
-    patch :p1 do
-      url "https://github.com/libvirt/libvirt/commit/591cb9d0d5e40eeff60cb18845197508b2878940.patch"
-      sha256 "ef24eb83a328e391bb44684e9664b3c4083b9c60864a78c22b7c0ea5268926f6"
+  # [libvirt PATCH 0/5] meson: Introduce qemu_datadir option - https://listman.redhat.com/archives/libvir-list/2021-November/msg00425.html
+  # [libvirt PATCH 1/5] meson: Define qemu_moddir correctly - https://listman.redhat.com/archives/libvir-list/2021-November/msg00426.html
+  patch :p1 do
+    url "https://github.com/libvirt/libvirt/commit/591cb9d0d5e40eeff60cb18845197508b2878940.patch"
+    sha256 "ef24eb83a328e391bb44684e9664b3c4083b9c60864a78c22b7c0ea5268926f6"
   end
   # [libvirt PATCH 2/5] qemu: Set QEMU data location correctly - https://listman.redhat.com/archives/libvir-list/2021-November/msg00427.html
   patch :p1 do

--- a/Formula/qemu.rb
+++ b/Formula/qemu.rb
@@ -1,122 +1,117 @@
 class Qemu < Formula
-    desc "Emulator for x86 and PowerPC"
-    homepage "https://www.qemu.org/"
-    license "GPL-2.0-only"
-    revision 1
-    head "https://git.qemu.org/git/qemu.git"
-  
-    stable do
-      url "https://download.qemu.org/qemu-6.0.0.tar.xz"
-      sha256 "87bc1a471ca24b97e7005711066007d443423d19aacda3d442558ae032fa30b9"
-    
-      # utm patch
-      patch do
-        url "https://github.com/utmapp/UTM/raw/master/patches/qemu-6.0.0.patch"
-        sha256 "3cc668069bdadde0d390de16e657dd4c0bb30f020ed5f0b55f38fb7ddf9edfec"
-      end
+  desc "Emulator for x86 and PowerPC"
+  homepage "https://www.qemu.org/"
+  url "https://download.qemu.org/qemu-6.1.0.tar.xz"
+  sha256 "eebc089db3414bbeedf1e464beda0a7515aad30f73261abc246c9b27503a3c96"
+  license "GPL-2.0-only"
+  revision 1
+  head "https://git.qemu.org/git/qemu.git", branch: "master"
 
-      # xcode 12.5 version header fix
-      patch do
-        url "https://github.com/akihikodaki/qemu/commit/c1db57c4362f44e50f1411d8dde79d768c2bb999.patch"
-        sha256 "a4c52faaf94535932b3a8638e01408e57563ff541a6fe8658dbe06029a09ea5d"
-      end
+  depends_on "libtool" => :build
+  depends_on "meson" => :build
+  depends_on "ninja" => :build
+  depends_on "pkg-config" => :build
+
+  depends_on "glib"
+  depends_on "gnutls"
+  depends_on "jpeg"
+  depends_on "libpng"
+  depends_on "libslirp"
+  depends_on "libssh"
+  depends_on "libusb"
+  depends_on "lzo"
+  depends_on "ncurses"
+  depends_on "nettle"
+  depends_on "pixman"
+  depends_on "snappy"
+  depends_on "vde"
+
+  on_linux do
+    depends_on "gcc"
+  end
+
+  fails_with gcc: "5"
+
+  # 820KB floppy disk image file of FreeDOS 1.2, used to test QEMU
+  resource "test-image" do
+    url "https://www.ibiblio.org/pub/micro/pc-stuff/freedos/files/distributions/1.2/FD12FLOPPY.zip"
+    sha256 "81237c7b42dc0ffc8b32a2f5734e3480a3f9a470c50c14a9c4576a2561a35807"
+  end
+
+  if Hardware::CPU.arm?
+    patch do
+      url "https://patchwork.kernel.org/series/548227/mbox/"
+      sha256 "5b9c9779374839ce6ade1b60d1377c3fc118bc43e8482d0d3efa64383e11b6d3"
     end
-  
-    #bottle do
-    #end
-  
-    depends_on "libtool" => :build
-    depends_on "meson" => :build
-    depends_on "ninja" => :build
-    depends_on "pkg-config" => :build
-  
-    depends_on "glib"
-    depends_on "gnutls"
-    depends_on "jpeg"
-    depends_on "libpng"
-    depends_on "libslirp"
-    depends_on "libssh"
-    depends_on "libusb"
-    depends_on "lzo"
-    depends_on "ncurses"
-    depends_on "nettle"
-    depends_on "pixman"
-    depends_on "snappy"
-    depends_on "vde"
-  
-    # 820KB floppy disk image file of FreeDOS 1.2, used to test QEMU
-    resource "test-image" do
-      url "https://www.ibiblio.org/pub/micro/pc-stuff/freedos/files/distributions/1.2/FD12FLOPPY.zip"
-      sha256 "81237c7b42dc0ffc8b32a2f5734e3480a3f9a470c50c14a9c4576a2561a35807"
+
+    patch do 
+      url "https://patchew.org/QEMU/20211112091414.34223-1-yaroshchuk2000@gmail.com/mbox"
+      sha256 "4d7824dbe4becadc645071768c6c726a0655e372c8f180e6b455f7f2e52dad77"
     end
-  
-    def install
-      ENV["LIBTOOL"] = "glibtool"
-  
-      args = %W[
-        --prefix=#{prefix}
-        --cc=#{ENV.cc}
-        --host-cc=#{ENV.cc}
-        --disable-debug-info
-        --disable-bsd-user
-        --disable-guest-agent
-        --enable-curses
-        --enable-libssh
-        --enable-slirp=system
-        --enable-vde
-        --enable-lto
-        --extra-cflags=-DNCURSES_WIDECHAR=1
-        --disable-sdl
-        --disable-gtk
-      ]
-      # Sharing Samba directories in QEMU requires the samba.org smbd which is
-      # incompatible with the macOS-provided version. This will lead to
-      # silent runtime failures, so we set it to a Homebrew path in order to
-      # obtain sensible runtime errors. This will also be compatible with
-      # Samba installations from external taps.
-      args << "--smbd=#{HOMEBREW_PREFIX}/sbin/samba-dot-org-smbd"
-  
-      on_macos do
-        args << "--enable-cocoa"
-      end
-  
-      system "./configure", *args
-      system "make", "V=1", "install"
-    end
-  
-    test do
-      expected = build.stable? ? version.to_s : "QEMU Project"
-      assert_match expected, shell_output("#{bin}/qemu-system-aarch64 --version")
-      assert_match expected, shell_output("#{bin}/qemu-system-alpha --version")
-      assert_match expected, shell_output("#{bin}/qemu-system-arm --version")
-      assert_match expected, shell_output("#{bin}/qemu-system-cris --version")
-      assert_match expected, shell_output("#{bin}/qemu-system-hppa --version")
-      assert_match expected, shell_output("#{bin}/qemu-system-i386 --version")
-      assert_match expected, shell_output("#{bin}/qemu-system-m68k --version")
-      assert_match expected, shell_output("#{bin}/qemu-system-microblaze --version")
-      assert_match expected, shell_output("#{bin}/qemu-system-microblazeel --version")
-      assert_match expected, shell_output("#{bin}/qemu-system-mips --version")
-      assert_match expected, shell_output("#{bin}/qemu-system-mips64 --version")
-      assert_match expected, shell_output("#{bin}/qemu-system-mips64el --version")
-      assert_match expected, shell_output("#{bin}/qemu-system-mipsel --version")
-      assert_match expected, shell_output("#{bin}/qemu-system-moxie --version")
-      assert_match expected, shell_output("#{bin}/qemu-system-nios2 --version")
-      assert_match expected, shell_output("#{bin}/qemu-system-or1k --version")
-      assert_match expected, shell_output("#{bin}/qemu-system-ppc --version")
-      assert_match expected, shell_output("#{bin}/qemu-system-ppc64 --version")
-      assert_match expected, shell_output("#{bin}/qemu-system-riscv32 --version")
-      assert_match expected, shell_output("#{bin}/qemu-system-riscv64 --version")
-      assert_match expected, shell_output("#{bin}/qemu-system-rx --version")
-      assert_match expected, shell_output("#{bin}/qemu-system-s390x --version")
-      assert_match expected, shell_output("#{bin}/qemu-system-sh4 --version")
-      assert_match expected, shell_output("#{bin}/qemu-system-sh4eb --version")
-      assert_match expected, shell_output("#{bin}/qemu-system-sparc --version")
-      assert_match expected, shell_output("#{bin}/qemu-system-sparc64 --version")
-      assert_match expected, shell_output("#{bin}/qemu-system-tricore --version")
-      assert_match expected, shell_output("#{bin}/qemu-system-x86_64 --version")
-      assert_match expected, shell_output("#{bin}/qemu-system-xtensa --version")
-      assert_match expected, shell_output("#{bin}/qemu-system-xtensaeb --version")
-      resource("test-image").stage testpath
-      assert_match "file format: raw", shell_output("#{bin}/qemu-img info FLOPPY.img")
-    end
+  end
+
+  def install
+    ENV["LIBTOOL"] = "glibtool"
+
+    args = %W[
+      --prefix=#{prefix}
+      --cc=#{ENV.cc}
+      --host-cc=#{ENV.cc}
+      --disable-bsd-user
+      --disable-guest-agent
+      --enable-curses
+      --enable-libssh
+      --enable-slirp=system
+      --enable-vde
+      --extra-cflags=-DNCURSES_WIDECHAR=1
+      --disable-sdl
+      --disable-gtk
+    ]
+    # Sharing Samba directories in QEMU requires the samba.org smbd which is
+    # incompatible with the macOS-provided version. This will lead to
+    # silent runtime failures, so we set it to a Homebrew path in order to
+    # obtain sensible runtime errors. This will also be compatible with
+    # Samba installations from external taps.
+    args << "--smbd=#{HOMEBREW_PREFIX}/sbin/samba-dot-org-smbd"
+
+    args << "--enable-cocoa" if OS.mac?
+
+    system "./configure", *args
+    system "make", "V=1", "install"
+  end
+
+  test do
+    expected = build.stable? ? version.to_s : "QEMU Project"
+    assert_match expected, shell_output("#{bin}/qemu-system-aarch64 --version")
+    assert_match expected, shell_output("#{bin}/qemu-system-alpha --version")
+    assert_match expected, shell_output("#{bin}/qemu-system-arm --version")
+    assert_match expected, shell_output("#{bin}/qemu-system-cris --version")
+    assert_match expected, shell_output("#{bin}/qemu-system-hppa --version")
+    assert_match expected, shell_output("#{bin}/qemu-system-i386 --version")
+    assert_match expected, shell_output("#{bin}/qemu-system-m68k --version")
+    assert_match expected, shell_output("#{bin}/qemu-system-microblaze --version")
+    assert_match expected, shell_output("#{bin}/qemu-system-microblazeel --version")
+    assert_match expected, shell_output("#{bin}/qemu-system-mips --version")
+    assert_match expected, shell_output("#{bin}/qemu-system-mips64 --version")
+    assert_match expected, shell_output("#{bin}/qemu-system-mips64el --version")
+    assert_match expected, shell_output("#{bin}/qemu-system-mipsel --version")
+    assert_match expected, shell_output("#{bin}/qemu-system-nios2 --version")
+    assert_match expected, shell_output("#{bin}/qemu-system-or1k --version")
+    assert_match expected, shell_output("#{bin}/qemu-system-ppc --version")
+    assert_match expected, shell_output("#{bin}/qemu-system-ppc64 --version")
+    assert_match expected, shell_output("#{bin}/qemu-system-riscv32 --version")
+    assert_match expected, shell_output("#{bin}/qemu-system-riscv64 --version")
+    assert_match expected, shell_output("#{bin}/qemu-system-rx --version")
+    assert_match expected, shell_output("#{bin}/qemu-system-s390x --version")
+    assert_match expected, shell_output("#{bin}/qemu-system-sh4 --version")
+    assert_match expected, shell_output("#{bin}/qemu-system-sh4eb --version")
+    assert_match expected, shell_output("#{bin}/qemu-system-sparc --version")
+    assert_match expected, shell_output("#{bin}/qemu-system-sparc64 --version")
+    assert_match expected, shell_output("#{bin}/qemu-system-tricore --version")
+    assert_match expected, shell_output("#{bin}/qemu-system-x86_64 --version")
+    assert_match expected, shell_output("#{bin}/qemu-system-xtensa --version")
+    assert_match expected, shell_output("#{bin}/qemu-system-xtensaeb --version")
+    resource("test-image").stage testpath
+    assert_match "file format: raw", shell_output("#{bin}/qemu-img info FLOPPY.img")
+  end
 end


### PR DESCRIPTION
I just added your patch to the current libvirt 7.9.0 formula and removed the bottles. I tested against QEMU 6.1 from the homebrew-core repo and it works well enough aside from broken networking. Your qemu formula still fails to build because there's a broken link to the UTM 6.0.0 patch.